### PR TITLE
LIBVA_DRIVER_NAME needs to be used if set at all

### DIFF
--- a/va/va.c
+++ b/va/va.c
@@ -544,8 +544,7 @@ VAStatus vaInitialize (
         va_infoMessage("User requested driver '%s'\n", driver_name);
     }
 
-    if ((VA_STATUS_SUCCESS == vaStatus) &&
-        driver_name_env && (geteuid() == getuid())) {
+    if (driver_name_env && (geteuid() == getuid())) {
         /* Don't allow setuid apps to use LIBVA_DRIVER_NAME */
         if (driver_name) /* memory is allocated in va_getDriverName */
             free(driver_name);


### PR DESCRIPTION
va_GetDriverName fails to find the vdpau driver returning
something != SUCCESS and the driver name is not used at all.

Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=72822
Change-Id: I29ef398bf066badedc25de10873975ad0479dccf
Signed-off-by: Philippe Coval rzr@gna.org
